### PR TITLE
Implement CSRF token refresh on API responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  after_action :set_csrf_token_header
+
+  private
+
+  def set_csrf_token_header
+    return unless protect_against_forgery?
+    return unless request.format.json?
+
+    response.headers["X-CSRF-Token"] = form_authenticity_token
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,8 +8,8 @@ module Users
       render json: { user: UserSerializer.new(resource).serializable_hash }, status: :ok
     end
 
-    def respond_to_on_destroy
-      head :no_content
+    def respond_to_on_destroy(non_navigational_status: :no_content)
+      head non_navigational_status
     end
   end
 end

--- a/app/frontend/lib/api.js
+++ b/app/frontend/lib/api.js
@@ -1,5 +1,15 @@
+function csrfMetaTag() {
+  return document.querySelector('meta[name="csrf-token"]');
+}
+
 function csrfToken() {
-  return document.querySelector('meta[name="csrf-token"]')?.content;
+  return csrfMetaTag()?.content;
+}
+
+function updateCsrfToken(res) {
+  const token = res.headers.get("X-CSRF-Token");
+  const meta = csrfMetaTag();
+  if (token && meta) meta.content = token;
 }
 
 async function request(url, { method = "GET", body } = {}) {
@@ -13,6 +23,8 @@ async function request(url, { method = "GET", body } = {}) {
     body: body ? JSON.stringify(body) : undefined,
     credentials: "same-origin",
   });
+
+  updateCsrfToken(res);
 
   const isJson = res.headers.get("content-type")?.includes("application/json");
   const data = isJson ? await res.json() : null;


### PR DESCRIPTION
## Summary
Adds automatic CSRF token refresh mechanism to keep the frontend's CSRF token in sync with the server across API requests. This ensures the token remains valid even when the server rotates it.

## Changes

**Frontend (`app/frontend/lib/api.js`)**
- Extract CSRF meta tag lookup into a new `csrfMetaTag()` helper function
- Refactor `csrfToken()` to use the new helper
- Add `updateCsrfToken(res)` function that extracts the `X-CSRF-Token` header from API responses and updates the DOM meta tag if present
- Call `updateCsrfToken(res)` after every API request to keep the token current

**Backend (`app/controllers/application_controller.rb`)**
- Add `after_action` hook to set the `X-CSRF-Token` response header on all JSON requests
- Implement `set_csrf_token_header` private method that includes the current CSRF token in the response header when CSRF protection is enabled and the request format is JSON

**Sessions Controller (`app/controllers/users/sessions_controller.rb`)**
- Update `respond_to_on_destroy` to accept a `non_navigational_status` parameter (defaults to `:no_content`)
- Pass the parameter to the `head` call for flexibility in response status codes

## Implementation Details
- The CSRF token refresh is transparent to the application—it happens automatically on every API response
- Only JSON requests receive the token header, keeping non-JSON responses unaffected
- The frontend gracefully handles missing headers (uses optional chaining and conditional checks)
- This pattern aligns with Rails' built-in CSRF protection while supporting modern SPA architectures

https://claude.ai/code/session_01N9NeWXhBt2JQoGNmA5tMEq